### PR TITLE
Add Content-Type header to all responses from fastboot

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ module.exports = function({ bucket, manifestKey, healthCheckerUA, sentryDSN, fas
   let beforeMiddleware = app => {
     app.use(healthChecker({ uaString: healthCheckerUA }));
     app.use(preview({ bucket }));
+    app.use((req, res, next) => res.type('text/html'));
   }
 
   if (fastbootConfig.distPath) {

--- a/index.js
+++ b/index.js
@@ -25,7 +25,10 @@ module.exports = function({ bucket, manifestKey, healthCheckerUA, sentryDSN, fas
   let beforeMiddleware = app => {
     app.use(healthChecker({ uaString: healthCheckerUA }));
     app.use(preview({ bucket }));
-    app.use((req, res, next) => res.type('text/html'));
+    app.use((req, res, next) => {
+      res.type('text/html');
+      next();
+    });
   }
 
   if (fastbootConfig.distPath) {


### PR DESCRIPTION
This fixes a problem with the twitter crawler (and others, theoretically) by setting a `Content-Type` header to responses from the fastboot server.

In practice, this is fine, since the fastboot app server is only ever returning a rendered HTML document. All other requests go straight to S3 for an asset or an API server for data (and sometimes, publisher itself).

In development, running the fastboot server (i.e. `$ node fastboot.js`) will cause trouble, since all asset requests will hit fastboot, so e.g. JPEGs will return with their `Content-Type` set as `text/html`.

Running the fastboot server locally is not a common thing. One would usually only do this for debugging or troubleshooting (it's not the same as the typical development command `$ ember serve`), so maybe this is fine for release. Maybe there's a switch we can add to turn this middleware off as an option when necessary? Of course we could also try to inspect the requested filepath and update the content type accordingly, but that seems like more work than we need to do right now.