### PR TITLE
adding in extra namespacing for statsd metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ const server = fastboot({
   bucket: process.env.AWS_BUCKET,
   manifestKey: process.env.FASTBOOT_MANIFEST,
   healthCheckerUA: 'ELB-HealthChecker',
-  sentryDSN: process.env.SENTRY_DSN
+  sentryDSN: process.env.SENTRY_DSN,
+  env: process.env.ENV,
+  serviceName: process.env.SERVICE_NAME
 });
 
 server.start();
@@ -28,6 +30,8 @@ const server = fastboot({
   healthCheckerUA: 'ELB-HealthChecker',
   sentryDSN: process.env.SENTRY_DSN,
   fastbootConfig: { port: 5000 },
+  env: process.env.ENV,
+  serviceName: process.env.SERVICE_NAME
 })
 ```
 
@@ -63,3 +67,9 @@ To configure sentry, create a new project at https://sentry.wnyc.org/sentry/.
 The creation of that project will automatically generate a DSN. It will look something like this: `https://<KEY>@sentry.wnyc.org/<PROJECT_ID>`.
  
 In the project that imports this library, make sure to include the `sentryDSN` parameter when initializing the fastboot server. Best practices around this are to set `sentryDSN` to an environment variable which can be configured at deployment time.
+
+## Statsd
+Statsd is a metrics collection and aggregation agent that can plug into a number of backends. We use it to send application metrics to our graphite backend. The collector is installed on the same machine that graphite runs on, and the client responsible for generating and sending metrics is included as a middleware here. The source code can be found here: https://github.com/uber/express-statsd
+
+The `env` and `serviceName` parameters passed into the fastboot constructor are used to namespace the metrics being sent to statsd. Examples of these parameters are `env: 'demo'` and `serviceName: 'wnyc-studios-web-client'`.
+

--- a/index.js
+++ b/index.js
@@ -17,6 +17,9 @@ module.exports = function({ bucket, manifestKey, healthCheckerUA, sentryDSN, fas
 
   fastbootConfig = {...FASTBOOT_DEFAULTS, ...fastbootConfig};
 
+  env = process.env.ENV || 'dev'
+  service = process.env.SERVICE || 'fastboot'
+
   if (sentryDSN) {
     Sentry.init({ dsn: sentryDSN });
   } else {
@@ -44,7 +47,7 @@ referrer\:":referrer"|\
 agent\:":user-agent"|\
 duration\::response-time"}',
         { skip: req => req.headers['user-agent'] == 'ELB-HealthChecker/2.0' }));
-    app.use(statsd({host: 'graphite.nypr.digital'}));
+    app.use(statsd({host: 'graphite.nypr.digital', requestKey: env+'.'+service}));
     app.use(healthChecker({ uaString: healthCheckerUA }));
     app.use(preview({ bucket }));
     app.use((req, res, next) => {

--- a/index.js
+++ b/index.js
@@ -13,12 +13,9 @@ const FASTBOOT_DEFAULTS = {
   chunkedResponse: true,
 };
 
-module.exports = function({ bucket, manifestKey, healthCheckerUA, sentryDSN, fastbootConfig = {} }) {
+module.exports = function({ bucket, manifestKey, healthCheckerUA, sentryDSN, fastbootConfig = {}, env = 'dev', serviceName = 'fastboot' }) {
 
   fastbootConfig = {...FASTBOOT_DEFAULTS, ...fastbootConfig};
-
-  env = process.env.ENV || 'dev'
-  service = process.env.SERVICE || 'fastboot'
 
   if (sentryDSN) {
     Sentry.init({ dsn: sentryDSN });


### PR DESCRIPTION
Currently the statsd metrics are namespaced as follows `stats.type_of_metric.metric_name` this will change it to be `stats.env.service.type_of_metric.metric_name` which will allow us to separate metrics by env and service.

The environment variables used here should be set at the service level, e.g. in the wnyc-studios-web-client circle project