### PR TITLE
testing out this method for setting the statsdKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The creation of that project will automatically generate a DSN. It will look som
 In the project that imports this library, make sure to include the `sentryDSN` parameter when initializing the fastboot server. Best practices around this are to set `sentryDSN` to an environment variable which can be configured at deployment time.
 
 ## Statsd
-Statsd is a metrics collection and aggregation agent that can plug into a number of backends. We use it to send application metrics to our graphite backend. The collector is installed on the same machine that graphite runs on, and the client responsible for generating and sending metrics is included as a middleware here. The source code can be found here: https://github.com/uber/express-statsd
+Statsd is a metrics collection and aggregation agent that can plug into a number of backends. We use it to send application metrics to our graphite backend. The collector is installed on the same machine that graphite runs on, and the client responsible for generating and sending metrics is included as a middleware in the lib directory.
 
-The `env` and `serviceName` parameters passed into the fastboot constructor are used to namespace the metrics being sent to statsd. Examples of these parameters are `env: 'demo'` and `serviceName: 'wnyc-studios-web-client'`.
+The `env` and `serviceName` parameters passed into the fastboot constructor are used to namespace the metrics being sent to statsd. Examples of these parameters are `env: 'demo'` and `serviceName: 'wnyc-studios-web-client'`. Passing in these parameters will produce a metric with the following name `stats.demo.wnyc-studios-web-client.<metric_type>.<metric_name>`.
 

--- a/index.js
+++ b/index.js
@@ -44,11 +44,12 @@ referrer\:":referrer"|\
 agent\:":user-agent"|\
 duration\::response-time"}',
         { skip: req => req.headers['user-agent'] == 'ELB-HealthChecker/2.0' }));
-    app.use(statsd({host: 'graphite.nypr.digital', requestKey: env+'.'+serviceName}));
+    app.use(statsd({host: 'graphite.nypr.digital'}));
     app.use(healthChecker({ uaString: healthCheckerUA }));
     app.use(preview({ bucket }));
     app.use((req, res, next) => {
       res.type('text/html');
+      req.statsdKey = env+'.'+serviceName
       next();
     });
   }

--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ const S3Downloader = require('fastboot-s3-downloader');
 const S3Notifier = require('fastboot-s3-notifier');
 const Sentry = require('@sentry/node');
 const morgan = require('morgan');
-const statsd = require('express-statsd')
 
+const statsd = require('./lib/statsd-client-middleware')
 const healthChecker = require('./lib/health-checker-middleware');
 const preview = require('./lib/preview-middleware');
 
@@ -44,12 +44,11 @@ referrer\:":referrer"|\
 agent\:":user-agent"|\
 duration\::response-time"}',
         { skip: req => req.headers['user-agent'] == 'ELB-HealthChecker/2.0' }));
-    app.use(statsd({host: 'graphite.nypr.digital'}));
+    app.use(statsd({host: 'graphite.nypr.digital', namespace: `${env}.${serviceName}`}));
     app.use(healthChecker({ uaString: healthCheckerUA }));
     app.use(preview({ bucket }));
     app.use((req, res, next) => {
       res.type('text/html');
-      req.statsdKey = env+'.'+serviceName
       next();
     });
   }

--- a/lib/statsd-client-middleware.js
+++ b/lib/statsd-client-middleware.js
@@ -1,0 +1,48 @@
+var extend = require('obj-extend');
+var Lynx = require('lynx');
+
+module.exports = function statsdClientInit (options) {
+  options = extend({
+    namespace: '',
+    host: '127.0.0.1',
+    port: 8125
+  }, options);
+
+  var client = options.client || new Lynx(options.host, options.port, options);
+
+  return function expressStatsd (req, res, next) {
+    var startTime = new Date().getTime();
+
+    // Function called on response finish that sends stats to statsd
+    function sendStats() {
+      var key = options.namespace;
+      key = key ? key + '.' : '';
+
+      // Status Code
+      var statusCode = res.statusCode || 'unknown_status';
+      client.increment(key + 'status_code.' + statusCode);
+
+      // Response Time
+      var duration = new Date().getTime() - startTime;
+      client.timing(key + 'response_time', duration);
+
+      cleanup();
+    }
+
+    // Function to clean up the listeners we've added
+    function cleanup() {
+      res.removeListener('finish', sendStats);
+      res.removeListener('error', cleanup);
+      res.removeListener('close', cleanup);
+    }
+
+    // Add response listeners
+    res.once('finish', sendStats);
+    res.once('error', cleanup);
+    res.once('close', cleanup);
+
+    if (next) {
+      next();
+    }
+  };
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nypr-fastboot",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "FastBoot Server for NYPR Apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,11 +20,12 @@
     "@sentry/node": "4.4.2",
     "aws-sdk": "^2.279.1",
     "eslint": "^5.2.0",
-    "express-statsd": "^0.3.0",
     "fastboot-app-server": "^1.1.2-beta.1",
     "fastboot-s3-downloader": "^0.2.2",
     "fastboot-s3-notifier": "^0.1.2",
-    "morgan": "^1.9.1"
+    "lynx": "^0.2.0",
+    "morgan": "^1.9.1",
+    "obj-extend": "^0.1.0"
   },
   "devDependencies": {
     "aws-sdk-mock": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -632,13 +632,6 @@ exists-sync@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/exists-sync/-/exists-sync-0.0.4.tgz#9744c2c428cc03b01060db454d4b12f0ef3c8879"
 
-express-statsd@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/express-statsd/-/express-statsd-0.3.0.tgz#cb60b8e4f633adc7eaaefb5819698b469c00b1bd"
-  dependencies:
-    lynx "~0.0.11"
-    obj-extend "~0.1.0"
-
 express@^4.13.3:
   version "4.16.3"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.3.tgz#6af8a502350db3246ecc4becf6b5a34d22f7ed53"
@@ -1190,9 +1183,9 @@ lsmod@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lsmod/-/lsmod-1.0.0.tgz#9a00f76dca36eb23fa05350afe1b585d4299e64b"
 
-lynx@~0.0.11:
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/lynx/-/lynx-0.0.11.tgz#2cfa14e443fd2d92a59b779f41567ce1cc6965a3"
+lynx@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/lynx/-/lynx-0.2.0.tgz#79e6674530da4183e87953bd686171e070da50b9"
   dependencies:
     mersenne "~0.0.3"
     statsd-parser "~0.0.4"
@@ -1323,7 +1316,7 @@ oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-obj-extend@~0.1.0:
+obj-extend@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/obj-extend/-/obj-extend-0.1.0.tgz#bb448a4775fb95eb34a781f908bbac2df23dbb5b"
 


### PR DESCRIPTION
I misunderstood this line of code completely https://github.com/uber/express-statsd/blob/master/lib/express-statsd.js#L21. 

So the way to namespace the statsd metric, is by reading a field called `statsdKey` which is set on the request. I thought it was just coming from the constructor.

My question about this PR is - will setting the req.statsdKey as I do, be done in time to get caught by the express-statsd middleware? or do I need to set the req.statsdKey higher up in the middleware chain?