### PR TITLE
Add path option to health checker middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,15 @@ module.exports = function({ bucket, manifestKey, healthCheckerUA, sentryDSN, log
     app.use(logger(loggerOptions));
 
     app.use(statsd({host: 'graphite.nypr.digital', namespace: `${env}.${serviceName}`}));
-    app.use(healthChecker({ uaString: healthCheckerUA }));
+
+    if (healthCheckerUA) {
+      // eslint-disable-next-line
+      console.warn("Health Checker User Agent string provided. Please upgrade to using the path strategy.");
+      app.use(healthChecker({ uaString: healthCheckerUA }));
+    } else {
+      app.use('/_health', healthChecker({strategy: 'path'}));
+    }
+
     app.use(preview({ bucket }));
 
     app.use((_req, res, next) => {

--- a/lib/health-checker-middleware.js
+++ b/lib/health-checker-middleware.js
@@ -16,7 +16,7 @@ function findStrategy(options = {}) {
     return STRATEGIES.UA_SNIFF(options.uaString || options.string);
   }
 
-  if (options.path || options.strategy === 'path') {
+  if (options.strategy === 'path') {
     return STRATEGIES.PATH_HANDLER;
   }
 

--- a/lib/health-checker-middleware.js
+++ b/lib/health-checker-middleware.js
@@ -1,9 +1,31 @@
-module.exports = function ({ uaString = '' }) {
-  return function healthChecker({ headers }, res, next) {
-    let { 'user-agent':ua = '' } = headers;
-    if (ua.match(uaString)) {
-      return res.sendStatus(200);
+const STRATEGIES = {
+  UA_SNIFF(uaString) {
+    return function({ headers }, res, next) {
+      let { 'user-agent':ua = '' } = headers;
+      if (ua.match(uaString)) {
+        return res.sendStatus(200);
+      }
+      return next();
     }
-    return next();
+  },
+  PATH_HANDLER: (_req, res) => res.sendStatus(200),
+}
+
+function findStrategy(options = {}) {
+  if (options.uaString || options.strategy === 'ua-sniff') {
+    return STRATEGIES.UA_SNIFF(options.uaString || options.string);
+  }
+
+  if (options.path || options.strategy === 'path') {
+    return STRATEGIES.PATH_HANDLER;
+  }
+
+}
+
+module.exports = function(options = {}) {
+  let strategy = findStrategy(options);
+
+  return function healthChecker(req, res, next) {
+    return strategy(req, res, next);
   }
 }

--- a/test/health-checker.js
+++ b/test/health-checker.js
@@ -40,5 +40,30 @@ describe('health checker middleware', function() {
 
     next.verify();
     response.sendStatus.verify();
-  })
+  });
+
+  it('respects the new API, sending a 200 at the configured route', function() {
+    const response = {sendStatus: sinon.mock('send response').withArgs(200).once()};
+    const next = sinon.mock('next').never();
+
+    const healthChecker = middleware({strategy: 'path'});
+
+    healthChecker({}, response, next);
+
+    next.verify();
+    response.sendStatus.verify();
+  });
+
+  it('respects the new API, responding to a UA string', function() {
+    const UA_STRING = 'foo-bar';
+    const response = {sendStatus: sinon.mock('send response').withArgs(200).once()};
+    const next = sinon.mock('next').never();
+
+    const healthChecker = middleware({ strategy: 'ua-sniff', string: UA_STRING });
+
+    healthChecker({ headers: {'user-agent': UA_STRING }}, response, next);
+
+    next.verify();
+    response.sendStatus.verify();
+  });
 });

--- a/test/health-checker.js
+++ b/test/health-checker.js
@@ -16,7 +16,7 @@ describe('health checker middleware', function() {
     response.sendStatus.verify();
   });
 
-  it('it sends an empty 200 on partial matches', async function() {
+  it('it sends an empty 200 on partial matches', function() {
     const UA_STRING = 'foo';
     const response = {sendStatus: sinon.mock('send response').withArgs(200).once()};
     const next = sinon.mock('next').never();
@@ -29,7 +29,7 @@ describe('health checker middleware', function() {
     response.sendStatus.verify();
   });
 
-  it('calls next if the user agent does not match', async function() {
+  it('calls next if the user agent does not match', function() {
     const UA_STRING = 'foo-bar';
     const response = {sendStatus: sinon.mock('send response').never()};
     const next = sinon.mock('next').once();


### PR DESCRIPTION
The idea is to make this backward compatible. We can eliminate the ua string options for `v1.0.0`.