### PR TITLE
Serve static from Express when Fastboot is running locally (e.g. in Docker)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
+const path = require('path');
 const express = require('express');
+
 const FastBootAppServer = require('fastboot-app-server');
 const S3Downloader = require('fastboot-s3-downloader');
 const S3Notifier = require('fastboot-s3-notifier');
@@ -46,10 +48,12 @@ module.exports = function({ bucket, manifestKey, healthCheckerUA, sentryDSN, log
 
     if (fastbootConfig.distPath) {
       // if distPath isn't set, we're running locally
-      let assetPath = path.join(__dirname, 'assets');
+      let assetPath = path.join(fastbootConfig.distPath, 'assets');
+      console.log('TKTK distPath is:');
+      console.log(distPath);
       console.log('TKTK set assetPath to');
       console.log(assetPath);
-      app.use('/assets', express.static());
+      app.use('/assets', express.static(assetPath));
     } else {
       // if not running locally,
       // static assets will be served from CDN

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const express = require('express');
 const FastBootAppServer = require('fastboot-app-server');
 const S3Downloader = require('fastboot-s3-downloader');
 const S3Notifier = require('fastboot-s3-notifier');
@@ -44,7 +45,10 @@ module.exports = function({ bucket, manifestKey, healthCheckerUA, sentryDSN, log
     app.use(preview({ bucket }));
 
     if (fastbootConfig.distPath) {
-      app.use(express.static('/assets'));
+      let assetPath = path.join(__dirname, 'assets');
+      console.log('TKTK set assetPath to');
+      console.log(assetPath);
+      app.use('/assets', express.static());
     }
 
     app.use((_req, res, next) => {

--- a/index.js
+++ b/index.js
@@ -44,21 +44,17 @@ module.exports = function({ bucket, manifestKey, healthCheckerUA, sentryDSN, log
     app.use(preview({ bucket }));
 
     if (fastbootConfig.distPath) {
-      // if distPath is set, we're running locally
+      // if distPath ist set, we're running locally
       const path = require('path');
       const express = require('express');
       let assetPath = path.join(fastbootConfig.distPath, 'assets');
       app.use('/assets', express.static(assetPath));
-    } else {
-      // if not running locally,
-      // static assets will be served from CDN
-      // w correct content-type, so just default
-      // to serving text/html from Fastboot
-      app.use((_req, res, next) => {
-        res.type('text/html');
-        next();
-    });
     }
+    // default to marking everything else text/html
+    app.use((_req, res, next) => {
+      res.type('text/html');
+      next();
+    });
   }
 
   if (fastbootConfig.distPath) {

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = function({ bucket, manifestKey, healthCheckerUA, sentryDSN, log
     app.use(preview({ bucket }));
 
     if (fastbootConfig.distPath) {
-      // if distPath isn't set, we're running locally
+      // if distPath is set, we're running locally
       const path = require('path');
       const express = require('express');
       let assetPath = path.join(fastbootConfig.distPath, 'assets');

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = function({ bucket, manifestKey, healthCheckerUA, sentryDSN, log
     app.use(preview({ bucket }));
 
     if (fastbootConfig.distPath) {
-      // if distPath ist set, we're running locally
+      // if distPath is set, we're running locally
       const path = require('path');
       const express = require('express');
       let assetPath = path.join(fastbootConfig.distPath, 'assets');

--- a/index.js
+++ b/index.js
@@ -43,6 +43,10 @@ module.exports = function({ bucket, manifestKey, healthCheckerUA, sentryDSN, log
 
     app.use(preview({ bucket }));
 
+    if (fastbootConfig.distPath) {
+      app.use(express.static('/assets'));
+    }
+
     app.use((_req, res, next) => {
       res.type('text/html');
       next();

--- a/index.js
+++ b/index.js
@@ -45,16 +45,21 @@ module.exports = function({ bucket, manifestKey, healthCheckerUA, sentryDSN, log
     app.use(preview({ bucket }));
 
     if (fastbootConfig.distPath) {
+      // if distPath isn't set, we're running locally
       let assetPath = path.join(__dirname, 'assets');
       console.log('TKTK set assetPath to');
       console.log(assetPath);
       app.use('/assets', express.static());
-    }
-
-    app.use((_req, res, next) => {
-      res.type('text/html');
-      next();
+    } else {
+      // if not running locally,
+      // static assets will be served from CDN
+      // w correct content-type, so just default
+      // to serving text/html from Fastboot
+      app.use((_req, res, next) => {
+        res.type('text/html');
+        next();
     });
+    }
   }
 
   if (fastbootConfig.distPath) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,3 @@
-const path = require('path');
-const express = require('express');
-
 const FastBootAppServer = require('fastboot-app-server');
 const S3Downloader = require('fastboot-s3-downloader');
 const S3Notifier = require('fastboot-s3-notifier');
@@ -48,11 +45,9 @@ module.exports = function({ bucket, manifestKey, healthCheckerUA, sentryDSN, log
 
     if (fastbootConfig.distPath) {
       // if distPath isn't set, we're running locally
+      const path = require('path');
+      const express = require('express');
       let assetPath = path.join(fastbootConfig.distPath, 'assets');
-      console.log('TKTK distPath is:');
-      console.log(distPath);
-      console.log('TKTK set assetPath to');
-      console.log(assetPath);
       app.use('/assets', express.static(assetPath));
     } else {
       // if not running locally,


### PR DESCRIPTION
We can run clients that use Fastboot in Docker locally by setting the `distPath` to the folder where Fastboot should look for that app, but this configuration won't serve static files with the correct content-types by default, since those are typically not served by Fastboot in production. Instead, when our apps are not running locally, Fastboot defaults to assigning a type of `text/html` to everything it returns. This is fine, unless it's running locally, in which case some assets (e.g. CSS) will not be loaded properly.

This change checks to see if distPath is set and, if so, uses Express to serve static assets, and it will set the correct content-type headers in the response. With this setting, it should be possible to run clients in Fastboot, on Squash.io, and connect them to arbitrary QA CMS instances to QA/review complicated tickets.